### PR TITLE
feat: list 명령어 구현 (현 서버의 모든 유저 보여주기)

### DIFF
--- a/src/commands/list.ts
+++ b/src/commands/list.ts
@@ -1,0 +1,42 @@
+import {logger} from "../logger.js";
+import {MongoUtil} from "../util/mongoUtil.js";
+import {ChatInputCommandInteraction, SlashCommandBuilder} from "discord.js";
+import {TimeUtil} from "../util/timeUtil.js";
+
+function formatDailyTime(dailyTime: string) {
+    if (dailyTime) {
+        return TimeUtil.formatDailyTime(dailyTime)
+    }
+    return "미등록"
+}
+
+export default {
+    data: new SlashCommandBuilder()
+        .setName('list')
+        .setDescription('등록된 모든 백준 아이디 목록을 보여드립니다.'),
+    async execute(interaction: ChatInputCommandInteraction) {
+        try {
+            const guildId = interaction.guildId
+            if (!guildId) {
+                await interaction.reply("서버 정보를 가져올 수 없습니다. 명령을 취소합니다.")
+                return;
+            }
+
+            const users = await MongoUtil.findAllUserInGuild(guildId);
+            if (!users || users.length === 0) {
+                await interaction.reply(`등록된 유저가 없습니다. \n/quit을 통해 아이디를 등록해주세요.`)
+                return;
+            }
+
+            const userInfo = users.map(user => {
+                return `백준 아이디: ${user.boj_id} | 매일 알림 시간: ${formatDailyTime(user.daily_time)}`;
+            }).join('\n')
+
+            await interaction.reply(userInfo)
+            return;
+        } catch (error: any) {
+            await interaction.reply("알 수 없는 오류가 발생했습니다.")
+            logger.error(error.message)
+        }
+    }
+}

--- a/src/commands/register.ts
+++ b/src/commands/register.ts
@@ -35,8 +35,14 @@ export default {
                 return;
             }
 
+            const guildId = interaction.guildId
+            if(!guildId){
+                await interaction.reply("서버 정보를 가져올 수 없습니다. 명령을 취소합니다.")
+                return;
+            }
+
             await interaction.reply({embeds: [getUserInfo(realUser)]})
-            const response = await MongoUtil.addUser(interaction.user.id, boj_id!);
+            const response = await MongoUtil.addUser(interaction.user.id, boj_id!, guildId);
             if (response) {
                 await interaction.followUp("정상적으로 등록되었습니다.")
                 logger.info(`${interaction.user.id} / ${boj_id} 가입 완료`)

--- a/src/embedMessage/guideMessage.ts
+++ b/src/embedMessage/guideMessage.ts
@@ -17,6 +17,7 @@ export const embedWelcome = new EmbedBuilder()
         { name: '/categorylist', value: '/category 사용 전, 알고리즘 분류 목록표를 보여드립니다.', inline: false },
         { name: '/quit', value: '백준 ID를 제거합니다. 봇을 제거할 시 정보 또한 동일하게 제거됩니다.', inline: false },
         { name: '/deactivate', value: '일일 문제 알림 수신을 비활성화 합니다.', inline: false },
+        { name: '/list', value: '등록된 모든 백준 아이디 목록을 보여드립니다.', inline: false },
         { name: '\u200B', value: '\u200B' },
         { name: '업데이트 로그는 다음 링크에서 확인해주세요.', value: 'https://github.com/boaz-baekjoon/baekjoon-discord-bot/releases', inline: false },
     )

--- a/src/model/mongodb_user_schema.ts
+++ b/src/model/mongodb_user_schema.ts
@@ -6,12 +6,14 @@ interface IUser extends mongoose.Document {
     discord_id: string;
     boj_id: string;
     daily_time: string;
+    guild_id: string;
 }
 
 const UserSchema = new mongoose.Schema({
     discord_id: {type: String, required: true},
     boj_id: {type: String, required: true},
-    daily_time: {type: String, required: false}
+    daily_time: {type: String, required: false},
+    guild_id: {type: String, required: false} // not required for backward compatibility
 });
 
 export const Mongodb_user_schema = mongoose.model<IUser>('Mongodb_use_schema', UserSchema, 'boj_user');

--- a/src/util/mongoUtil.ts
+++ b/src/util/mongoUtil.ts
@@ -1,21 +1,21 @@
-import * as mongoose from 'mongoose';
-import { Mongodb_user_schema } from '../model/mongodb_user_schema.js';
+import {Mongodb_user_schema} from '../model/mongodb_user_schema.js';
 import {logger} from "../logger.js";
 import {Problem} from "../model/problem_schema.js";
 import {BojProblem} from "../model/problem_class.js";
-import {ClientSession} from "typeorm";
 import {Report} from "../model/report_schema.js";
 
 export class MongoUtil{
     //map discordId and bojId, and save it to mongoDB
-    static async addUser(userDiscordId: string, userBojId: string): Promise<boolean>{
+    static async addUser(userDiscordId: string, userBojId: string, guildId: string): Promise<boolean>{
         try{
             const user = new Mongodb_user_schema({
                 discord_id: userDiscordId,
                 boj_id: userBojId,
+                daily_time: null,
+                guild_id: guildId,
             });
             await user.save();
-            logger.info(`Adding user ${userDiscordId} with boj id ${userBojId}`);
+            logger.info(`Adding user ${userDiscordId} with boj id ${userBojId} in guild ${guildId}`);
             return true;
         }catch (error: any){
             logger.error(error.message);

--- a/src/util/mongoUtil.ts
+++ b/src/util/mongoUtil.ts
@@ -127,6 +127,20 @@ export class MongoUtil{
         }
     }
 
+    static async findAllUserInGuild(guildId: string): Promise<any>{
+        try{
+            const users = await Mongodb_user_schema.find({guild_id: guildId});
+            logger.info(`Finding all users in guild ${guildId}`);
+            if (users){
+                return users;
+            }else {
+                return null;
+            }
+        }catch (error: any){
+            logger.error(error.message);
+        }
+    }
+
     //find problem with problemId
     static async findProblemWithProblemId(problemId: number): Promise<any>{
         try {

--- a/src/util/timeUtil.ts
+++ b/src/util/timeUtil.ts
@@ -1,0 +1,12 @@
+export class TimeUtil {
+    static formatDailyTime(dailyTime: string): string {
+        let [hh, mm] = dailyTime.split(' ')
+        if (hh.length === 1) {
+            hh = `0${hh}`
+        }
+        if (mm.length === 1) {
+            mm = `0${mm}`
+        }
+        return `${hh}:${mm}`
+    }
+}


### PR DESCRIPTION
- resolves https://github.com/boaz-baekjoon/baekjoon-discord-bot/issues/38

![Screenshot 2024-09-02 at 00 15 28 by seonghyeok](https://github.com/user-attachments/assets/f4d33ef8-eb3b-47f7-9e18-252b8c62a04e)

![Screenshot 2024-09-02 at 00 15 19 by seonghyeok](https://github.com/user-attachments/assets/8d3fb67c-6091-4132-9791-cfbf8b808584)

## 소개

- 전체 등록된 유저들을 보고 싶어서 기능을 추가했습니다. 피드백 부탁드립니다!

## 특이사항

- 해당 서버의 유저들만 보여줘야 했기에, guildId (server id) 를 user schema 에 추가했습니다.
- 시간 포맷을 통일하기 위해 유틸 코드를 추가했습니다 (오전 1시 3분 --> 01:03)